### PR TITLE
fix: remove unused code, add server.close()

### DIFF
--- a/sh/integration-tests.sh
+++ b/sh/integration-tests.sh
@@ -3,8 +3,6 @@
 # bash script mode
 set -euo pipefail
 
-trap 'kill $(jobs -p)' EXIT
-
 set -a
 source .env.development
 set +a
@@ -19,6 +17,6 @@ echo "[test] Spawning server process..."
 
 echo "[test] running tests using mocha"
 # run the tests
-NODE_ENV=development ./node_modules/.bin/mocha --recursive --bail --exit ./test/integration/
+./node_modules/.bin/mocha --recursive --bail --exit ./test/integration/
 
 echo "[/test]"

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -40,6 +40,7 @@ before(() => {
 });
 
 // runs after all tests are completed
-after(() => {
+after((done) => {
   console.log('Test suite completed.');
+  global.agent.close((err) => { done(err); });
 });


### PR DESCRIPTION
Adds the .close() method to the agent in the mocha after() block. Removes the trap function from the bash script to prevent it screwing up the integration tests.